### PR TITLE
fixed android camera zoom bug

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,0 +1,48 @@
+/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */html,body,p,ol,ul,li,dl,dt,dd,blockquote,figure,fieldset,legend,textarea,pre,iframe,hr,h1,h2,h3,h4,h5,h6{margin:0;padding:0}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal}ul{list-style:none}button,input,select,textarea{margin:0}html{box-sizing:border-box}*,*::before,*::after{box-sizing:inherit}img{height:auto;max-width:100%}iframe{border:0}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}td:not([align]),th:not([align]){text-align:left}
+
+/* *** FONTS *** */
+/* latin-ext */
+@font-face {
+  font-family: 'DINOT-Regular';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('DINOT Regular'), local('DINOT-Regular'), url(https://assets.contentstack.io/v3/assets/blte63f7056be4da683/blt18dd5a021f4af85d/5f67d680d70e764f32921bea/DINOT-Regular.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'DINOT-Regular';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('DINOT Regular'), local('DINOT-Regular'), url(https://assets.contentstack.io/v3/assets/blte63f7056be4da683/blt18dd5a021f4af85d/5f67d680d70e764f32921bea/DINOT-Regular.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* *** GLOBAL *** */
+html {
+  overflow: hidden; /* need this to prevent page from scrolling! */
+}
+
+body {
+  font-size: 16px;
+  line-height: 1em;
+  overflow: hidden;
+  width: 100vw;
+  height: 100vh;
+  font-family: 'DINOT-Regular', Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  position: relative;
+  background: #000000;
+}
+
+main {
+  overflow:hidden;
+}
+
+a {
+  text-decoration: none;
+  text-align: center;
+  color: #ffffff;
+  text-transform: uppercase;
+}

--- a/src/css/scenario1.css
+++ b/src/css/scenario1.css
@@ -1,45 +1,3 @@
-/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */html,body,p,ol,ul,li,dl,dt,dd,blockquote,figure,fieldset,legend,textarea,pre,iframe,hr,h1,h2,h3,h4,h5,h6{margin:0;padding:0}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal}ul{list-style:none}button,input,select,textarea{margin:0}html{box-sizing:border-box}*,*::before,*::after{box-sizing:inherit}img{height:auto;max-width:100%}iframe{border:0}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}td:not([align]),th:not([align]){text-align:left}
-
-/* *** FONTS *** */
-/* latin-ext */
-@font-face {
-  font-family: 'DINOT-Regular';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: local('DINOT Regular'), local('DINOT-Regular'), url(https://assets.contentstack.io/v3/assets/blte63f7056be4da683/blt18dd5a021f4af85d/5f67d680d70e764f32921bea/DINOT-Regular.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-/* latin */
-@font-face {
-  font-family: 'DINOT-Regular';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: local('DINOT Regular'), local('DINOT-Regular'), url(https://assets.contentstack.io/v3/assets/blte63f7056be4da683/blt18dd5a021f4af85d/5f67d680d70e764f32921bea/DINOT-Regular.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* *** GLOBAL *** */
-html {
-  overflow: hidden; /* need this to prevent page from scrolling! */
-}
-
-body {
-  font-size: 16px;
-  line-height: 1em;
-  overflow: hidden;
-  width: 100vw;
-  height: 100vh;
-  font-family: 'DINOT-Regular', Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  position: relative;
-  background: #000000;
-}
-
-main {
-  overflow:hidden;
-}
-
 /* *** S1 HUD *** */
 #scanner {
   padding: 14.5vw;
@@ -212,10 +170,6 @@ main {
 
 /* *** S1 BUTTONS *** */
 a {
-  text-decoration: none;
-  text-align: center;
-  color: #ffffff;
-  text-transform: uppercase;
   opacity: 0;
   visibility: collapse;
   transition: opacity 0.5s cubic-bezier(0.25, 1, 0.5, 1);

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Spyglass Demo • Skincare • Contentstack + Valtech + AR</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link href="./scenario1/main.css" rel="stylesheet">
+	<link href="./css/main.css" rel="stylesheet">
 	<style>
 		body {
 			color: #ffffff;

--- a/src/scenario1/index.html
+++ b/src/scenario1/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <title>Spyglass Scenario 1 • Contentstack + Valtech + AR</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="./main.css" rel="stylesheet" />
+    <link href="../css/main.css" rel="stylesheet" />
+    <link href="../css/scenario1.css" rel="stylesheet" />
     <!-- favicon generics -->
 	<link rel="icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-32.png" sizes="32x32">
 	<link rel="icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-57.png" sizes="57x57">

--- a/src/scenario2/index.html
+++ b/src/scenario2/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Spyglass Scenario 2 • Contentstack + Valtech + AR</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="../css/main.css" rel="stylesheet" />
     <!-- favicon generics -->
 	<link rel="icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-32.png" sizes="32x32">
 	<link rel="icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-57.png" sizes="57x57">
@@ -18,7 +19,6 @@
 	<link rel="apple-touch-icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-120.png" sizes="120x120">
 	<link rel="apple-touch-icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-152.png" sizes="152x152">
 	<link rel="apple-touch-icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-180.png" sizes="180x180">
-    <!--    <link href="./main.css" rel="stylesheet">-->
     <!-- A-Frame -->
     <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <!--    <script src="https://aframe.io/releases/0.9.2/aframe.min.js"></script>-->

--- a/src/scenario3/index.html
+++ b/src/scenario3/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Spyglass Scenario 3 • Contentstack + Valtech + AR</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="../css/main.css" rel="stylesheet" />
 	<!-- favicon generics -->
 	<link rel="icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-32.png" sizes="32x32">
 	<link rel="icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-57.png" sizes="57x57">
@@ -18,7 +19,6 @@
 	<link rel="apple-touch-icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-120.png" sizes="120x120">
 	<link rel="apple-touch-icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-152.png" sizes="152x152">
 	<link rel="apple-touch-icon" href="https://spyglass.valtech.engineering/images/favicons/favicon-180.png" sizes="180x180">
-    <!--    <link href="./main.css" rel="stylesheet">-->
     <!-- A-Frame -->
     <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <!--    <script src="https://aframe.io/releases/0.9.2/aframe.min.js"></script>-->


### PR DESCRIPTION
- created dedicated css folder
- separated main.css into separate files
- bringing in main.css to scenario1 and scenario2 to fix zoom problem

The bug was occurring when we were not styling the body element in scenario2 and scenario3. In main.css, we are setting, amongst other things, width, height and overflow values for the body element. When these are not set, the body's child element, <main>, appears to be applying calculated width and height values that are too large (creating the zoomed appearance). 
The reason this is isolated to Android may be to do with the order of DOM loading / when the first width and height calculations are first detecting parent dimensions and being set.

Testing:
- requires testing on iPhone to make sure it hasn't broken it